### PR TITLE
Update Gemfile source and rspec version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'yard'
@@ -9,7 +9,7 @@ end
 
 group :test do
   gem 'json', :platforms => :ruby_18
-  gem 'rspec'
+  gem 'rspec', '~> 2.99'
   gem 'timecop'
   gem 'webmock', '>= 1.10.1'
 end


### PR DESCRIPTION
This is a small update to to the project Gemfile to rspec at the expected version, and to point at the HTTPS version of Rubygems.org. The specs then pass with supported Ruby versions (anything above 1.8 really).