### PR TITLE
Coerce BookmarkList bookmarks to correct format

### DIFF
--- a/lib/instapaper/http/utils.rb
+++ b/lib/instapaper/http/utils.rb
@@ -60,6 +60,11 @@ module Instapaper
         if response.key?('hash')
           response['instapaper_hash'] = response.delete('hash')
         end
+        if response.key?('bookmarks')
+          response['bookmarks'] = response['bookmarks'].collect {|bookmark|
+            coerce_hash(bookmark)
+          }
+        end
         response
       end
     end

--- a/spec/instapaper/api/bookmarks_spec.rb
+++ b/spec/instapaper/api/bookmarks_spec.rb
@@ -27,6 +27,11 @@ describe Instapaper::Client::Bookmarks do
         expect(bookmark).to be_an Instapaper::Bookmark
       end
     end
+
+    it 'coerces bookmarks correctly' do
+      list = client.bookmarks
+      expect(list.bookmarks.first.instapaper_hash).to_not be_nil
+    end
   end
 
   describe '#update_read_progress' do


### PR DESCRIPTION
Previously fetching all bookmarks caused the `instapaper_hash` not being set.