### PR TITLE
Allow using recent versions of http.rb

### DIFF
--- a/instapaper.gemspec
+++ b/instapaper.gemspec
@@ -4,7 +4,7 @@ require 'instapaper/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
-  spec.add_dependency 'http', '~> 2'
+  spec.add_dependency 'http', '>= 2', '< 6'
   spec.add_dependency 'multi_json', '~> 1'
   spec.add_dependency 'simple_oauth', '~> 0.3'
   spec.add_dependency 'virtus', '~> 1'


### PR DESCRIPTION
Most of the major breaking changes to http.rb since 2.x were to drop old Ruby versions that are no longer supported so it looks safe to allow up to the current version, 5.x.

There was a failing test when I cloned the repo and I haven't looked into that or done any manual testing (this is blocking me from trying it in my project). But all the tests that passed when I cloned it pass now, and I browsed through the http.rb changes since 2.0.